### PR TITLE
Add Syncfusion AI assets page

### DIFF
--- a/CoboAI/AiAssetsPage.xaml
+++ b/CoboAI/AiAssetsPage.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:syncfusion="clr-namespace:Syncfusion.Maui.DataGrid;assembly=Syncfusion.Maui.DataGrid"
+             x:Class="CoboAI.AiAssetsPage"
+             Title="AI Assets">
+    <syncfusion:SfDataGrid x:Name="AssetsGrid"
+                           AutoGenerateColumns="True"
+                           ItemsSource="{Binding Assets}" />
+</ContentPage>

--- a/CoboAI/AiAssetsPage.xaml.cs
+++ b/CoboAI/AiAssetsPage.xaml.cs
@@ -1,0 +1,21 @@
+using System.Collections.ObjectModel;
+
+namespace CoboAI;
+
+public partial class AiAssetsPage : ContentPage
+{
+    public ObservableCollection<Asset> Assets { get; } = new();
+
+    public AiAssetsPage()
+    {
+        InitializeComponent();
+        BindingContext = this;
+
+        // Sample data
+        Assets.Add(new Asset("Robot Model", "3D"));
+        Assets.Add(new Asset("Car Dataset", "Images"));
+        Assets.Add(new Asset("Vision Model", "AI"));
+    }
+}
+
+public record Asset(string Name, string Type);

--- a/CoboAI/AppShell.xaml
+++ b/CoboAI/AppShell.xaml
@@ -8,6 +8,11 @@
     Title="CoboAI">
 
     <ShellContent
+        Title="Assets"
+        ContentTemplate="{DataTemplate local:AiAssetsPage}"
+        Route="AiAssetsPage" />
+
+    <ShellContent
         Title="Home"
         ContentTemplate="{DataTemplate local:MainPage}"
         Route="MainPage" />

--- a/CoboAI/CoboAI.csproj
+++ b/CoboAI/CoboAI.csproj
@@ -60,6 +60,8 @@
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+    <PackageReference Include="Syncfusion.Maui.Core" Version="25.1.37" />
+    <PackageReference Include="Syncfusion.Maui.DataGrid" Version="25.1.37" />
 	</ItemGroup>
 
 </Project>

--- a/CoboAI/MauiProgram.cs
+++ b/CoboAI/MauiProgram.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Syncfusion.Maui.Core.Hosting;
 
 namespace CoboAI
 {
@@ -9,6 +10,7 @@ namespace CoboAI
             var builder = MauiApp.CreateBuilder();
             builder
                 .UseMauiApp<App>()
+                .ConfigureSyncfusionCore()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");


### PR DESCRIPTION
## Summary
- add `AiAssetsPage` for displaying assets
- show the new page in the shell
- include Syncfusion DataGrid package references
- configure Syncfusion in app startup

## Testing
- `dotnet build CoboAI.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a775d232c8326bd2b7bc09f6c8598